### PR TITLE
removed fixing of build-nr to enable dependency-constraint updates fo…

### DIFF
--- a/bipp/meta.yaml
+++ b/bipp/meta.yaml
@@ -22,12 +22,12 @@ requirements:
     - python          {{ python }}
     - openblas
     - scikit-build
-    - finufft         ={{ FINUFFT_VERSION_ALT }}=*_0
+    - finufft         ={{ FINUFFT_VERSION_ALT }}
 
   run:
     - python           {{ python }}
     - openblas
-    - finufft          ={{ FINUFFT_VERSION_ALT }}=*_0
+    - finufft          ={{ FINUFFT_VERSION_ALT }}
     - {{ pin_compatible('numpy') }}
     - scikit-learn
     - astropy

--- a/hvox/meta.yaml
+++ b/hvox/meta.yaml
@@ -29,10 +29,10 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - healpy
     - ducc0
-    - pycsou                ={{ PYCSOU_VERSION_ALT }}=*_0
-    - rascil                ={{ RASCIL_VERSION_ALT }}=*_0
-    - ska-sdp-datamodels    ={{ SKA_SDP_DTMDL_VERSION_ALT }}=*_0
-    - ska-sdp-func-python   ={{ SKA_SDP_FUNC_PY_VERSION_ALT }}=*_0
+    - pycsou                ={{ PYCSOU_VERSION_ALT }}
+    - rascil                ={{ RASCIL_VERSION_ALT }}
+    - ska-sdp-datamodels    ={{ SKA_SDP_DTMDL_VERSION_ALT }}
+    - ska-sdp-func-python   ={{ SKA_SDP_FUNC_PY_VERSION_ALT }}
 
 about:
   home: "https://github.com/matthieumeo/hvox"

--- a/oskar-py/meta.yaml
+++ b/oskar-py/meta.yaml
@@ -20,12 +20,12 @@ requirements:
     - python      {{ python }}
     - pip
     - numpy
-    - oskar       ={{ OSKARPY_VERSION_ALT }}=*_0
+    - oskar       ={{ OSKARPY_VERSION_ALT }}
 
   run:
     - python      {{ python }}
     - {{ pin_compatible('numpy') }}
-    - oskar       ={{ OSKARPY_VERSION_ALT }}=*_0
+    - oskar       ={{ OSKARPY_VERSION_ALT }}
 
 about:
   home: https://github.com/OxfordSKA/OSKAR

--- a/rascil/meta.yaml
+++ b/rascil/meta.yaml
@@ -28,7 +28,7 @@ requirements:
   run:
     - python                {{ python }}
     - astropy               >=5.1,      <5.2  # <5.2 for RASCIL <= 1.0 (private import error)
-    - bdsf                  ={{ PYBDSF_VERSION_ALT }}=*_0
+    - bdsf                  ={{ PYBDSF_VERSION_ALT }}
     - dask                  >=2022.12
     - dask-memusage         >=1.1
     - distributed           >=2022.12
@@ -39,9 +39,9 @@ requirements:
     - reproject             >=0.9
     - scipy                 >=1.10.1
     - seqfile               >=0.2
-    - ska-sdp-datamodels    ={{ SKA_SDP_DTMDL_VERSION_ALT }}=*_0
-    - ska-sdp-func          ={{ SKA_SDP_FUNC_VERSION_ALT }}=*_0
-    - ska-sdp-func-python   ={{ SKA_SDP_FUNC_PY_VERSION_ALT }}=*_0
+    - ska-sdp-datamodels    ={{ SKA_SDP_DTMDL_VERSION_ALT }}
+    - ska-sdp-func          ={{ SKA_SDP_FUNC_VERSION_ALT }}
+    - ska-sdp-func-python   ={{ SKA_SDP_FUNC_PY_VERSION_ALT }}
     - tabulate              >=0.9
     - xarray                >=2022.12
 

--- a/ska-sdp-func-python/meta.yaml
+++ b/ska-sdp-func-python/meta.yaml
@@ -32,9 +32,9 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - photutils             >=1.5
     - scipy                 >=1.10.1
-    - ska-sdp-datamodels    ={{ SKA_SDP_DTMDL_VERSION_ALT }}=*_0
-    - ska-sdp-func          ={{ SKA_SDP_FUNC_VERSION_ALT }}=*_0
-    - xarray                >=2022.11.0
+    - ska-sdp-datamodels    ={{ SKA_SDP_DTMDL_VERSION_ALT }}
+    - ska-sdp-func          ={{ SKA_SDP_FUNC_VERSION_ALT }}
+    - xarray                <=2023.2  # see issue #542 of Karabo
 
 about:
   home: https://gitlab.com/ska-telescope/sdp/ska-sdp-func-python/


### PR DESCRIPTION
- removed fixing of build-nr to enable dependency-constraint updates for past releases
- constrained xarray for ska-sdp-func-python because of Karabo issue #542