### PR TITLE
fix #31 , remove noarch:python and add isNative:true for all packages

### DIFF
--- a/.github/workflows/build_ARatmospy.yml
+++ b/.github/workflows/build_ARatmospy.yml
@@ -14,7 +14,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -40,4 +40,5 @@ jobs:
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
       pythonCall: import aratmospy
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_Rascil.yml
+++ b/.github/workflows/build_Rascil.yml
@@ -18,7 +18,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -49,4 +49,5 @@ jobs:
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
       devDeps: ${{ inputs.devDeps }}
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_SKA_SDP_Datamodel.yml
+++ b/.github/workflows/build_SKA_SDP_Datamodel.yml
@@ -14,7 +14,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -40,4 +40,5 @@ jobs:
       label: ${{ inputs.label }}
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_SKA_SDP_Func_Python.yml
+++ b/.github/workflows/build_SKA_SDP_Func_Python.yml
@@ -18,7 +18,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -49,4 +49,5 @@ jobs:
       dev: ${{ inputs.dev }}
       devDeps: ${{ inputs.devDeps }}
       buildNumber: ${{ inputs.buildNumber }}
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_aotools.yml
+++ b/.github/workflows/build_aotools.yml
@@ -14,7 +14,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -40,4 +40,5 @@ jobs:
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
       pythonCall: import aotools
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_eidos.yml
+++ b/.github/workflows/build_eidos.yml
@@ -14,7 +14,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -40,4 +40,5 @@ jobs:
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
       pythonCall: import eidos
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_hvox.yml
+++ b/.github/workflows/build_hvox.yml
@@ -18,7 +18,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -49,4 +49,5 @@ jobs:
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
       devDeps: ${{ inputs.devDeps }}
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_katbeam.yml
+++ b/.github/workflows/build_katbeam.yml
@@ -14,7 +14,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -40,4 +40,5 @@ jobs:
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
       pythonCall: import katbeam
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_pycsou.yml
+++ b/.github/workflows/build_pycsou.yml
@@ -14,7 +14,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -40,4 +40,5 @@ jobs:
       label: ${{ inputs.label }}
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_seqfile.yml
+++ b/.github/workflows/build_seqfile.yml
@@ -14,7 +14,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -40,4 +40,5 @@ jobs:
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
       pythonCall: import seqfile
+      isNative: true
     secrets: inherit

--- a/.github/workflows/build_tools21cm.yml
+++ b/.github/workflows/build_tools21cm.yml
@@ -14,7 +14,7 @@ on:
       buildNumber:
         type: string
         required: true
-        
+
   workflow_call:
     inputs:
       label:
@@ -40,4 +40,5 @@ jobs:
       dev: ${{ inputs.dev }}
       buildNumber: ${{ inputs.buildNumber }}
       pythonCall: import tools21cm
+      isNative: true
     secrets: inherit

--- a/aotools/meta.yaml
+++ b/aotools/meta.yaml
@@ -6,12 +6,11 @@ source:
   url: "https://pypi.io/packages/source/{{ PACKAGE_NAME[0] }}/{{ PACKAGE_NAME }}/{{ PACKAGE_NAME }}-{{ AOTOOLS_VERSION }}.tar.gz"
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
 
 requirements:
-  build: 
+  build:
     - python
     - numpy
 
@@ -31,7 +30,7 @@ about:
   home: "https://github.com/aotools/aotools"
   license: UNKNOWN
   license_family: OTHER
-  license_file: 
+  license_file:
   summary: "A set of useful functions for Adaptive Optics in Python"
   doc_url: https://aotools.readthedocs.io/en/v1.0.1/
   dev_url: https://github.com/aotools/aotools

--- a/aratmospy/meta.yaml
+++ b/aratmospy/meta.yaml
@@ -7,7 +7,6 @@ source:
   git_rev: "67c302a136beb40a1cc88b054d7b62ccd927d64f"
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
 
@@ -33,7 +32,7 @@ about:
   home: "https://github.com/i4Ds/ARatmospy"
   license: MIT License or MIT
   license_family: MIT
-  license_file: 
+  license_file:
   summary: "Python version of autoregressive atmosphere generator."
   doc_url: "https://github.com/i4Ds/ARatmospy"
   dev_url: "https://github.com/i4Ds/ARatmospy"

--- a/eidos/meta.yaml
+++ b/eidos/meta.yaml
@@ -7,7 +7,6 @@ source:
   git_rev: 74ffe0552079486aef9b413efdf91756096e93e7
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
 

--- a/hvox/meta.yaml
+++ b/hvox/meta.yaml
@@ -7,7 +7,6 @@ source:
   git_rev: "bb9619ed33c782a76d2be32ca1f145d216425643"  # corresponds to 0.0.1.dev48
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
 
@@ -38,7 +37,7 @@ about:
   home: "https://github.com/matthieumeo/hvox"
   license: MIT License or MIT
   license_family: MIT
-  license_file: 
+  license_file:
   summary: "Python reference implementation of the HVOX gridder for mesh-agnostic wide-field interferometry."
   doc_url: "https://github.com/matthieumeo/hvox"
   dev_url: "https://github.com/matthieumeo/hvox"

--- a/katbeam/meta.yaml
+++ b/katbeam/meta.yaml
@@ -7,7 +7,6 @@ source:
   git_rev: 5ce6fcc35471168f4c4b84605cf601d57ced8d9e
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
 

--- a/pycsou/meta.yaml
+++ b/pycsou/meta.yaml
@@ -7,7 +7,6 @@ source:
   git_rev: "ad5d54268d1a752fc2c0c3f3e5becab29bf3afac"  # corresponds to 1.0.7.dev1679
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
 
@@ -37,7 +36,7 @@ about:
   home: "https://github.com/matthieumeo/pycsou"
   license: MIT License or MIT
   license_family: MIT
-  license_file: 
+  license_file:
   summary: "Pycsou is a Python 3 package for solving linear inverse problems with state-of-the-art proximal algorithms. The software implements in a highly modular way the main building blocks -cost functionals, penalty terms and linear operators- of generic penalised convex optimisation problems."
   doc_url: "https://github.com/matthieumeo/pycsou"
   dev_url: "https://github.com/matthieumeo/pycsou"

--- a/rascil/meta.yaml
+++ b/rascil/meta.yaml
@@ -7,7 +7,6 @@ source:
   git_tag: {{ RASCIL_VERSION }}
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
 
@@ -45,9 +44,6 @@ requirements:
     - ska-sdp-func-python   ={{ SKA_SDP_FUNC_PY_VERSION_ALT }}
     - tabulate              >=0.9
     - xarray                >=2022.12
-
-    
-   
 
 about:
   home: https://gitlab.com/ska-telescope/external/rascil-main

--- a/seqfile/meta.yaml
+++ b/seqfile/meta.yaml
@@ -6,7 +6,6 @@ source:
   url: "https://pypi.io/packages/source/{{ PACKAGE_NAME[0] }}/{{ PACKAGE_NAME }}/{{ PACKAGE_NAME }}-{{ SEQFILE_VERSION }}.tar.gz"
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
 #  entry_points:
@@ -30,10 +29,10 @@ about:
   home: "https://github.com/musically-ut/seqfile"
   license: MIT License or MIT
   license_family: MIT
-  license_file: 
+  license_file:
   summary: "Find the next file in a sequence of files in a thread-safe way."
-  doc_url: 
-  dev_url: 
+  doc_url:
+  dev_url:
 
 extra:
   recipe-maintainers:

--- a/ska-sdp-datamodels/meta.yaml
+++ b/ska-sdp-datamodels/meta.yaml
@@ -8,12 +8,11 @@ source:
    url: https://artefact.skao.int/repository/pypi-internal/packages/{{ PACKAGE_NAME }}/{{ SKA_SDP_DTMDL_VERSION }}/{{ uNameAndVers }}.tar.gz
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
   script_env:
     - INTERNAL_FOLDER_NAME={{ uNameAndVers }}
-  
+
 requirements:
   build:
     - python
@@ -24,7 +23,7 @@ requirements:
     - pip
     - numpy
     - poetry-core       >=1.0.0
-    
+
   run:
     - python            {{ python }}
     - astroplan         >=0.8

--- a/ska-sdp-func-python/meta.yaml
+++ b/ska-sdp-func-python/meta.yaml
@@ -8,12 +8,11 @@ source:
    url: https://artefact.skao.int/repository/pypi-internal/packages/{{ PACKAGE_NAME }}/{{ SKA_SDP_FUNC_PY_VERSION }}/{{ uNameAndVers }}.tar.gz
 
 build:
-  noarch: python
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
   script_env:
     - INTERNAL_FOLDER_NAME={{ uNameAndVers }}
-  
+
 requirements:
   build:
     - python
@@ -23,7 +22,7 @@ requirements:
     - python                {{ python }}
     - poetry-core           >=1.0.0
     - numpy
-    
+
   run:
     - python                {{ python }}
     - astroplan             >=0.8

--- a/tools21cm/meta.yaml
+++ b/tools21cm/meta.yaml
@@ -9,7 +9,6 @@ source:
 build:
   number: {{ build }}
   string: py{{ py }}h{{ PKG_HASH }}_{{ build }}
-  noarch: python
 
 requirements:
   build:


### PR DESCRIPTION
packages affected: tools21cm, aotools, aratmospy, eidos, hvox, katbeam, pycsou, rascil, seqfile, ska-sdp-datamodels, ska-sdp-func-python

if noarch, conda ignores the multiple python versions specified in conda_build_config.yaml. and builds a single wheel with a single python version constraint that is the last python version in the list.

I ran dev builds for all affected packages, and everything passes except:
- hvox and pycsou , although these appear to have already been broken.
- ska-sdp-spack doesn't work on python3.9 because this version is not included in the conda_build_config.yaml
- rascil seems to be taking a veeery long time https://github.com/i4Ds/Karabo-Feedstock/actions/runs/15634563751/job/44046420466 but I doubt this is related to this change.