### PR TITLE
pin idg,oskar,bipp,wsclean cmake version

### DIFF
--- a/bipp/meta.yaml
+++ b/bipp/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
   git_url: "https://github.com/epfl-radio-astro/bipp"
-  git_rev: "f13353bca7f4dbd9940eded3b96f98b75e98186e" 
+  git_rev: "f13353bca7f4dbd9940eded3b96f98b75e98186e"
 
 build:
   number: {{ build }}
@@ -16,8 +16,8 @@ requirements:
     - {{ compiler('cxx') }}
     - {{ compiler('gfortran') }}
     - python
-    - cmake
-    
+    - cmake >=3.10,<4
+
   host:
     - python          {{ python }}
     - openblas

--- a/idg/meta.yaml
+++ b/idg/meta.yaml
@@ -33,7 +33,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake
+    - cmake >=3.10,<4
     - make
     - fftw3f
     - libblas

--- a/oskar/meta.yaml
+++ b/oskar/meta.yaml
@@ -14,7 +14,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake
+    - cmake >=3.10,<4
     - make
 
   host:

--- a/wsclean/meta.yaml
+++ b/wsclean/meta.yaml
@@ -6,7 +6,7 @@ source:
   git_url: https://gitlab.com/aroffringa/wsclean.git
   # Cut off the .0 part in e.g. 3.4.0 we added just for conda build
   git_tag: "v{{ WSCLEAN_VERSION[:-2] }}"
- 
+
 
 build:
   number: {{ build }}
@@ -16,7 +16,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - cmake
+    - cmake >=3.10,<4
     - make
     - boost
     - casacore


### PR DESCRIPTION
since cmake 4 is now available, the check for cmake version in these projects fails unless cmake is pinned to version 3