### PR TITLE
pin casacore version 3.5.0

### DIFF
--- a/.github/workflows/build_base.yml
+++ b/.github/workflows/build_base.yml
@@ -15,6 +15,7 @@ env:
   # Oskar Line
   OSKAR_VERSION: 2.8.3
   OSKARPY_VERSION: 2.8.3  # oskarpy should have same version as `OSKAR_VERSION`
+  CASACORE_VERSION: 3.5.0
 
   # hvox Line -> don't add dev-label through ci-options because the setup is not ready for that.
   HVOX_VERSION: 0.0.1.dev48  # `pbr` version because they don't have an official release tag yet
@@ -22,8 +23,8 @@ env:
 
   # WSClean
   IDG_VERSION: 1.2.0
-  EVERYBEAM_VERSION: 0.6.1  #  0.5.7
-  WSCLEAN_VERSION: 3.5.0 #3.4.0
+  EVERYBEAM_VERSION: 0.6.1
+  WSCLEAN_VERSION: 3.5.0
 
 
   # additional karabo dependencies

--- a/everybeam/meta.yaml
+++ b/everybeam/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - cmake
     - make
     - boost
-    - casacore
+    - casacore={{ CASACORE_VERSION_ALT }}
     - cfitsio
     - conda-forge::fftw=*=mpi_mpich*
     - hdf5
@@ -30,7 +30,7 @@ requirements:
 
   host:
     - boost
-    - casacore
+    - casacore={{ CASACORE_VERSION_ALT }}
     - cfitsio
     - conda-forge::fftw=*=mpi_mpich*
     - hdf5
@@ -39,10 +39,10 @@ requirements:
     - libxml2
     - python
     - wcslib
-  
+
   run:
     - boost
-    - casacore
+    - casacore={{ CASACORE_VERSION_ALT }}
     - cfitsio
     - fftw
     - hdf5

--- a/oskar/meta.yaml
+++ b/oskar/meta.yaml
@@ -19,12 +19,12 @@ requirements:
     - make
 
   host:
-    - casacore
+    - casacore={{ CASACORE_VERSION_ALT }}
     - harp
     - hdf5
 
   run:
-    - casacore
+    - casacore={{ CASACORE_VERSION_ALT }}
     - harp
     - hdf5
 

--- a/wsclean/meta.yaml
+++ b/wsclean/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - cmake >=3.10,<4
     - make
     - boost
-    - casacore
+    - casacore={{ CASACORE_VERSION_ALT }}
     - cfitsio
     - everybeam={{ EVERYBEAM_VERSION_ALT }}
     - conda-forge::fftw=*=mpi_mpich*
@@ -33,7 +33,7 @@ requirements:
 
   host:
     - boost
-    - casacore
+    - casacore={{ CASACORE_VERSION_ALT }}
     - cfitsio
     - everybeam={{ EVERYBEAM_VERSION_ALT }}
     - conda-forge::fftw=*=mpi_mpich*
@@ -45,7 +45,7 @@ requirements:
 
   run:
     - boost
-    - casacore
+    - casacore={{ CASACORE_VERSION_ALT }}
     - cfitsio
     - everybeam={{ EVERYBEAM_VERSION_ALT }}
     - fftw


### PR DESCRIPTION
versions of casacore after 3.7 require cfitsio 4.5 which is incompatible with wsclean 3.5

```
The following packages are incompatible
├─ oskarpy 2.8.dev3**  is installable and it requires
│  └─ oskar 2.8.dev3.* , which requires
│     └─ casacore >=3.7.1,<3.8.0a0  with the potential options
│        ├─ casacore 3.7.1 would require
│        │  └─ cfitsio >=4.6.2,<4.6.3.0a0 , which can be installed;
│        ├─ casacore 3.7.1 would require
│        │  └─ cfitsio >=4.5.0,<4.5.1.0a0 , which can be installed;
│        └─ casacore 3.7.1 would require
│           └─ cfitsio >=4.6.0,<4.6.1.0a0 , which can be installed;
└─ wsclean 3.5.dev0**  is not installable because it requires
   └─ cfitsio >=4.3.1,<4.3.2.0a0 , which conflicts with any installable versions previously reported.
```

this adds a CASACORE_VERSION env to build_base which is used in everybeam, oskar, wsclean.

I've tested this with dev builds of everybeam, oskar, oskarpy, wsclean and they build. 

just waiting on the results of conda env create (even with libmamba this is taking forever)