### PR TITLE
bipp pin scipy 1.13

### DIFF
--- a/bipp/meta.yaml
+++ b/bipp/meta.yaml
@@ -36,10 +36,10 @@ requirements:
     - pyproj
     - healpy
     - pandas
-    # scipy pinnned to <1.15 because healpy 1.15.0 is incompatible with scipy >= 1.15
+    # scipy pinnned to <1.14 because healpy 1.15.0 is incompatible with scipy >= 1.13
     #   from scipy.integrate import trapz
     # newer healpy versions are available, unclear why these are not pulled in
-    - scipy            >=1.10.1,<1.15
+    - scipy            >=1.10.1,<1.14
 
 about:
   home: https://github.com/epfl-radio-astro/bipp


### PR DESCRIPTION
accidentally pinned to scipy <1.15 previously when it should have been <1.14